### PR TITLE
point to the new jsoncdc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - sudo ln -s ~/.cargo/bin/cargo /usr/local/bin/cargo
   - sudo ln -s ~/.cargo/bin/rustc /usr/local/bin/rustc
   - sudo easy_install pgxnclient
-  - sudo bash -c "pgxn install jsoncdc --unstable"
+  - sudo bash -c "pgxn install jsoncdc --testing"
 
 before_script:
   - sudo bash -c "cat test/config/bin-log.cnf >> /etc/mysql/conf.d/bin-log.cnf"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Getting Started
 Currently MySQL and PostgreSQL databases are fully supported. MongoDB supports inserts and deletes, however, updates
-return a copy of the operation (for example, a `$rename` operation will return a `$set` for the new field and an 
+return a copy of the operation (for example, a `$rename` operation will return a `$set` for the new field and an
 `$unset` for the old field) instead of the object as it exists in the database. Redis support is on the way. Lapidus can
 currently be used as a daemon or Node.js module. Support for piping line-delimited JSON to other processes is a high
 priority.
@@ -19,14 +19,16 @@ npm install -g lapidus
 
 ## PostgreSQL
 You'll need PostgreSQL 9.4 or higher with logical replication configured and the
-[JSONCDC](https://github.com/posix4e/jsoncdc) plugin installed and loaded. Any PostgreSQL fork that ships with
+[JSONCDC](https://github.com/instructure/jsoncdc) plugin installed and loaded. Any PostgreSQL fork that ships with
 `pg_recvlogical` *should* be compatible.
 
-**To install the [JSONCDC](https://github.com/posix4e/jsoncdc) logical decoding plugin using pgxn:**
+**To install the [JSONCDC](https://github.com/instructure/jsoncdc) logical decoding plugin using pgxn:**
 ```shell
 sudo easy_install pgxnclient
-pgxn install jsoncdc --unstable
+pgxn install jsoncdc --testing
 ```
+
+_NOTE: JSONCDC also provides .debs inside their releases repo, if you wish to not install through pgxn._
 
 **To enable logical decoding and the JSONCDC plugin add the following lines to your postgresql.conf:**
 ```
@@ -137,7 +139,7 @@ backend and publish all events to NATS using the NATS plugin:
       "password": "2PQM9aiKMJX5chv76gYdFJNi",
       "slot": "hurley_slot"
     },
-    
+
     {
       "type": "mongo",
       "hostname": "127.0.0.1",
@@ -186,7 +188,7 @@ messaging system.
       "database": "darma",
       "password": "notpennysboat123",
       "slot": "walts_raft",
-      
+
       "plugins": {
         "nats": {
           "server": "nats://localhost:4222"


### PR DESCRIPTION
this commit removes all references to the (now older) jsoncdc. pointing
to the new source repo "instructure/jsoncdc". it also installs the
latest version of jsoncdc which is available now on the "testing" channel
instead of unstable.

this shouldn't break anything with lapidus seeing as how the two changes are:
  - We release DEBs now (no impact).
  - We have a slightly longer rust line length (If this had an impact I'd
      be very confused).
  - We've added extra info to `commits`, but haven't removed any existing
    properties.
      (Perhaps in the future lapidus should pick up these properties?).
  - My editor also removed some whitespace that was in the readme. If you need me to readd these I can.